### PR TITLE
Implement SSL handshake timeout and move version to __init__

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Release date: TBD
 
+- Adds SSL handshake timeout with a default value of 5 seconds to prevent cases where clients don't support opportunistic encryption, but the server is configured to require it. **This works only with Python 3.7 and later.**
+- Modifies required version of smtpdfix to be between 1.3.1 and 1.4.2
+
 ## Version 0.3.0
 
 Release date: 2021-03-14

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased Changes
+
+Release date: TBD
+
 ## Version 0.3.0
 
 Release date: 2021-03-14

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,8 @@
 Release date: TBD
 
 - Adds SSL handshake timeout with a default value of 5 seconds to prevent cases where clients don't support opportunistic encryption, but the server is configured to require it. **This works only with Python 3.7 and later.**
-- Modifies required version of smtpdfix to be between 1.3.1 and 1.4.2
+- Modifies required version of smtpdfix to be between 1.3.1 and 1.4.2 to prevent breaking changes with ssl_handshake_timeout.
+- Moves metadata from `setup()` in setup.py to setup.cfg.
 
 ## Version 0.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiosmtpd==1.4.2
 atpublic==2.3
-attrs==20.3.0
+attrs==21.2.0
 cffi==1.14.5
 cryptography==3.4.7
 iniconfig==1.1.1
@@ -9,6 +9,6 @@ pluggy==0.13.1
 py==1.10.0
 pycparser==2.20
 pyparsing==2.4.7
-pytest==6.2.3
-python-dotenv==0.17.0
+pytest==6.2.4
+python-dotenv==0.17.1
 toml==0.10.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,36 @@
+[metadata]
+name = smtpdfix
+version = attr: smtpdfix.__version__
+url = https://github.com/bebleo/smtpdfix
+project_urls = 
+    Source = https://github.com/bebleo/smtpdfix
+    Documentation = https://smtpdfix.readthedocs.org
+license = MIT
+license_file = LICENSE
+author = James Warne
+author_email = bebleo@yahoo.com
+description = A mock SMTP server designed for use as a test fixture that 
+              implements encryption and authentication.
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers = 
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Framework :: Pytest
+
+[options]
+packages = find:
+python_requires = >= 3.6
+
+[options.entry_points]
+pytest11 =
+    smtpd = smtpdfix.fixture
+
 [tools:pytest]
 testpaths = tests
 log_cli = True

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,7 @@
-from setuptools import find_packages, setup
-
-version = "0.3.1-dev"
-
-with open("README.md", "rt", encoding="utf-8") as f:
-    long_description = f.read()
-
-short_description = ("A mock SMTP server designed for use as a test fixture "
-                     "that implements encryption and authentication.")
+from setuptools import setup
 
 setup(
     name="smtpdfix",
-    version=version,
-    author="James Warne",
-    author_email="bebleo@yahoo.com",
-    description=short_description,
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    packages=find_packages(),
-    url="https://github.com/bebleo/smtpdfix",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Framework :: Pytest",
-    ],
-    python_requires=">= 3.6",
     install_requires=[
         "aiosmtpd >= 1.3.1, <= 1.4.2",
         "cryptography >= 3.4.4",
@@ -44,8 +17,5 @@ setup(
             "pytest-timeout",
             "tox",
         ],
-    },
-    entry_points={
-        "pytest11": ["smtpd = smtpdfix.fixture"]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     python_requires=">= 3.6",
     install_requires=[
-        "aiosmtpd >= 1.3.1",
+        "aiosmtpd >= 1.3.1, <= 1.4.2",
         "cryptography >= 3.4.4",
         "pytest",
         "python-dotenv",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "0.3.0"
+version = "0.3.1-dev"
 
 with open("README.md", "rt", encoding="utf-8") as f:
     long_description = f.read()

--- a/smtpdfix/__init__.py
+++ b/smtpdfix/__init__.py
@@ -7,6 +7,7 @@ __all__ = (
     "smtpd",
     "SMTPDFix",
 )
+__version__ = "0.3.1a1"
 
 from .authenticator import Authenticator
 from .certs import generate_certs

--- a/smtpdfix/controller.py
+++ b/smtpdfix/controller.py
@@ -4,12 +4,17 @@ import logging
 import ssl
 from os import strerror
 from pathlib import Path
+from sys import version_info
+from typing import Coroutine
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.smtp import SMTP
 
 from .configuration import Config
 from .handlers import AuthMessage
+
+# For use as a type alias in AuthController._run
+AsyncServer = asyncio.base_events.Server
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +54,8 @@ class AuthController(Controller):
                          loop=_loop,
                          ready_timeout=ready_timeout,
                          ssl_context=context_or_none(),
-                         authenticator=self._authenticator)
+                         authenticator=self._authenticator,
+                         **kwargs)
 
         # The event handler for changes to the config goes here to prevent it
         # firing when the obkect is initialized.
@@ -111,6 +117,44 @@ class AuthController(Controller):
         asyncio.ensure_future(self.smtpd.push(status))
         self.smtpd.transport.close()
         self.server.close()
+
+    def _run(self, ready_event):
+        asyncio.set_event_loop(self.loop)
+        try:
+            # Need to do two-step assignments here to ensure IDEs can properly
+            # detect the types of the vars. Cannot use `assert isinstance`,
+            # because Python 3.6 in asyncio debug mode has a bug wherein
+            # CoroWrapper is not an instance of Coroutine
+            coro_kwargs = {}
+            if self.ssl_context and version_info >= (3, 7):
+                coro_kwargs["ssl_handshake_timeout"] = 5.0
+
+            srv_coro: Coroutine = self.loop.create_server(
+                self._factory_invoker,
+                host=self.hostname,
+                port=self.port,
+                ssl=self.ssl_context,
+                **coro_kwargs
+            )
+            self.server_coro = srv_coro
+            srv: AsyncServer = self.loop.run_until_complete(srv_coro)
+            self.server = srv
+        except Exception as error:  # pragma: on-wsl; # pragma: no cover
+            # Usually will enter this part only if create_server() cannot bind
+            # to the specified host:port.
+            #
+            # Somehow WSL 1.0 (Windows Subsystem for Linux) allows multiple
+            # listeners on one port?!
+            # That is why we add "pragma: on-wsl" there, so this block will not
+            # affect coverage on WSL 1.0.
+            self._thread_exception = error
+            return
+        self.loop.call_soon(ready_event.set)
+        self.loop.run_forever()
+        self.server.close()
+        self.loop.run_until_complete(self.server.wait_closed())
+        self.loop.close()
+        self.server = None
 
     def reset(self, persist_messages=True):
         _running = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ pytest_plugins = ["smtpdfix", "pytester"]
 
 
 def pytest_collection_modifyitems(items):
-    # Mark each test as timing out after 15 seconds to prevent the server
+    # Mark each test as timing out after 10 seconds to prevent the server
     # hanging on errors. Note that this can lead to the entire test run
     # failing.
     timeout_secs = 10

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -93,7 +93,7 @@ async def test_custom_cert_and_key(request, tmp_path_factory, msg):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7),
-                    reason="Known issue with timeout of SSL handshake")
+                    reason="No timeout of SSL handshake possible")
 async def test_TLS_not_supported(request, tmp_path_factory, msg, user):
     path = tmp_path_factory.mktemp("certs")
     generate_certs(path)
@@ -113,10 +113,10 @@ async def test_TLS_not_supported(request, tmp_path_factory, msg, user):
     with pytest.raises(SMTPServerDisconnected):
         with SMTP(server.hostname, server.port) as client:
             # this should return a 523 Encryption required error
-            # but instead it just hangs.
-            # client.login(user.username, user.password)
+            # but instead returns an SMTPServerDisconnected Error on
+            # Python 3.7 or later.
+            # Python 3.6 just hangs without timing out.
             client.send_message(msg)
-            # client.close()
             assert len(server.messages) == 1
 
 


### PR DESCRIPTION
Implements the SSL handshake timeout on python 3.7 and later (not available in 3.6 or eariler) to reduce the waiting time where a client will never complete.
Moves metadata from `setup()` to setup.cfg and version no. to `smtpdfix.__init__` as a prepatory step for documentation.