### PR TITLE
Switch to windows-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: macos-latest
             python-version: "3.10"
-          - os: windows-2022
+          - os: windows-latest
             python-version: "3.10"
     timeout-minutes: 5
 


### PR DESCRIPTION
We had explicitly set to run against windows server 2022 for tests, but since this is now the default on Github switching to windows-latest as the test runner to seamlessly take advantage of future versions.