### PR TITLE
Remove scheduled run from OSSF Scorecard

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -2,9 +2,7 @@ name: Scorecards supply-chain security
 on:
   # Only the default branch is supported.
   branch_protection_rule:
-  schedule:
-    - cron: '21 5 * * 5'
-  push:
+  pull_request:
     branches: [ main ]
 
 # Declare default permissions as read only.


### PR DESCRIPTION
Removes the scheduled run and swithes to running on pull_request
for the OSSF Scorecard action as a temporary fix for an issue
with the action.

See #127
