### PR TITLE
Modify setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,9 @@ dev =
 pytest11 =
     smtpd = smtpdfix.fixture
 
-[tools:pytest]
+[tool:pytest]
 testpaths = tests
-log_cli = True
+asyncio_mode = strict
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Modify setup.cfg to suppress the warning re: pytest-asycio mode
and correct the section in setup.cfg so that pytest reads it.