### PR TITLE
Drop python 3.6 support

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", pypy-3.6, pypy-3.7]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", pypy-3.6, pypy-3.7]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7]
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Release date: TBD
 
+- Support for python 3.6 has been dropped and python 3.7 or later is required.
+
 ## Version 0.3.3
 
 Release date: 2021-11-18

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/smtpdfix/controller.py
+++ b/smtpdfix/controller.py
@@ -6,7 +6,6 @@ from contextlib import ExitStack
 from os import strerror
 from pathlib import Path
 from socket import create_connection
-from sys import version_info
 from typing import Coroutine
 
 from aiosmtpd.controller import Controller, get_localhost
@@ -132,7 +131,7 @@ class AuthController(Controller):
             # because Python 3.6 in asyncio debug mode has a bug wherein
             # CoroWrapper is not an instance of Coroutine
             coro_kwargs = {}
-            if self.ssl_context and version_info >= (3, 7):
+            if self.ssl_context:
                 coro_kwargs["ssl_handshake_timeout"] = 5.0
 
             srv_coro: Coroutine = self.loop.create_server(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import ssl
-import sys
 from pathlib import Path
 from smtplib import SMTP, SMTP_SSL, SMTPSenderRefused, SMTPServerDisconnected
 
@@ -92,8 +91,6 @@ async def test_custom_cert_and_key(request, tmp_path_factory, msg):
     assert len(server.messages) == 1
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7),
-                    reason="No timeout of SSL handshake possible")
 async def test_TLS_not_supported(request, tmp_path_factory, msg, user):
     path = tmp_path_factory.mktemp("certs")
     _generate_certs(path)
@@ -113,9 +110,7 @@ async def test_TLS_not_supported(request, tmp_path_factory, msg, user):
     with pytest.raises(SMTPServerDisconnected):
         with SMTP(server.hostname, server.port) as client:
             # this should return a 523 Encryption required error
-            # but instead returns an SMTPServerDisconnected Error on
-            # Python 3.7 or later.
-            # Python 3.6 just hangs without timing out.
+            # but instead returns an SMTPServerDisconnected Error
             client.send_message(msg)
             assert len(server.messages) == 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, pypy3, cov, lint
+envlist = py37, py38, py39, py310, pypy3, cov, lint
 
 [testenv]
 passenv = PYTHON_VERSION


### PR DESCRIPTION
Support for python3.6 ended in December 2021 and many projects are
dropping support. SMTPDFix had code that required python3.7 or
later and was excluded using sys.version. Dropping support allows
us to drop those exceptions.

Specifically:
+ Setup now requires python3.7 or later
+ Dropped workaround for ssl_handshake_timeout added in python3.7
+ Tests are no longer skipped
+ Github Actions no longer use python3.6 or pypy3.6
+ Python3.6 dropped from tox config

Closes #113