### PR TITLE
Remove generate_certs from public API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,14 +5,15 @@
 Release date: TBD
 
 - Support for python 3.6 has been dropped and python 3.7 or later is required. [Issue #113](https://github.com/bebleo/smtpdfix/issues/113)
-- Corrects minor error in READMIE.md [Issue #140](https://github.com/bebleo/smtpdfix/issues/1400)
+- `generate_certs` has been removed from the public API. [Issue #95](https://github.com/bebleo/smtpdfix/issues/95)
+- Corrects minor error in READMIE.md [Issue #140](https://github.com/bebleo/smtpdfix/issues/140)
 
 ## Version 0.3.3
 
 Release date: 2021-11-18
 
 - Removes newline in description that causes errors when installing.
-- Updates the setup architecture to be inline with more recent reccomendations to use `setup.cfg` over `setup.py`/
+- Updates the setup architecture to be inline with more recent reccomendations to use `setup.cfg` over `setup.py`.
 
 ## Version 0.3.2
 

--- a/smtpdfix/__init__.py
+++ b/smtpdfix/__init__.py
@@ -10,7 +10,6 @@ __all__ = (
 __version__ = "0.4.0.dev"
 
 from .authenticator import Authenticator
-from .certs import generate_certs
 from .configuration import Config
 from .controller import AuthController
 from .fixture import SMTPDFix, smtpd

--- a/smtpdfix/certs.py
+++ b/smtpdfix/certs.py
@@ -1,6 +1,5 @@
 import logging
 import socket
-import warnings
 from datetime import datetime, timedelta
 from ipaddress import ip_address
 from pathlib import Path
@@ -62,11 +61,3 @@ def _generate_certs(path, days=3652, key_size=2048, separate_key=False):
     with open(cert_path, "ab") as f:
         f.write(cert.public_bytes(serialization.Encoding.PEM))
     log.debug("Certificate generated")
-
-
-def generate_certs(path, days=3652, key_size=2048, separate_key=False):
-    _message = ("_generate_certs will be removed from the public API as of ",
-                "version 0.4.")
-    warnings.warn(_message, PendingDeprecationWarning)
-
-    return _generate_certs(path, days, key_size, separate_key)

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,9 +1,0 @@
-import pytest
-
-from smtpdfix.certs import generate_certs
-
-
-def test_deprecate_gen_certs(tmp_path_factory):
-    path = tmp_path_factory.mktemp("tmp")
-    with pytest.warns(PendingDeprecationWarning):
-        generate_certs(path)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, pypy38, cov, lint
+envlist = py37, py38, py39, py310, pypy37, pypy38, cov, lint
 
 [testenv]
 passenv = PYTHON_VERSION


### PR DESCRIPTION
generate_certs has been deperecated from the public API and a
warning issued since version 0.3.3. This commit removes it and
the associated test.

Closes #95