### PR TITLE
Add PyPy 3.8 to tested versions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8]
 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8]
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, pypy3, cov, lint
+envlist = py37, py38, py39, py310, pypy38, cov, lint
 
 [testenv]
 passenv = PYTHON_VERSION


### PR DESCRIPTION
**PyPy support remains unofficial and may be dropped in the future.**

In addition to testing against PyPy 3.7 we should also test against PyPy 3.8.