### PR TITLE
Remove dependency on distutils

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Release date: TBD
 - `generate_certs` has been removed from the public API. [Issue #95](https://github.com/bebleo/smtpdfix/issues/95)
 - Corrects minor error in READMIE.md [Issue #140](https://github.com/bebleo/smtpdfix/issues/140)
 - Fixes a previously unreported bug where self-signed certificates would be rejected if no CA was generated and trusted. Now any certificate file, including the one generated internally, will be trusted.
+- Drops the dependecy on the `distutils` package in preparation for its removal with python 3.12. [Issue #114](https://github.com/bebleo/smtpdfix/issues/114)
 
 ## Version 0.3.3
 

--- a/smtpdfix/configuration.py
+++ b/smtpdfix/configuration.py
@@ -1,5 +1,4 @@
 import os
-from distutils.util import strtobool
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -8,6 +7,24 @@ from .event_handler import EventHandler
 
 _current_dir = Path(__file__).parent
 load_dotenv()
+
+
+def _strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are "y", "yes", "t", "true", "on", and "1"; false values are
+    "n", "no", "f", "false", "off", and "0".  Raises ValueError if "val" is
+    anything else.
+    """
+    # Copied and updated from distutils.util in response to distutils removal
+    # as of python 3.12
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val}")
 
 
 class Config():
@@ -22,24 +39,24 @@ class Config():
         self._ready_timeout = float(os.getenv("SMTPD_READY_TIMEOUT", 5.0))
         self._login_username = os.getenv("SMTPD_LOGIN_NAME", "user")
         self._login_password = os.getenv("SMTPD_LOGIN_PASSWORD", "password")
-        self._enforce_auth = strtobool(os.getenv("SMTPD_ENFORCE_AUTH",
-                                                 "False"))
-        self._auth_require_tls = strtobool(os.getenv("SMTPD_AUTH_REQUIRE_TLS",
-                                                     "True"))
+        self._enforce_auth = _strtobool(os.getenv("SMTPD_ENFORCE_AUTH",
+                                                  "False"))
+        self._auth_require_tls = _strtobool(os.getenv("SMTPD_AUTH_REQUIRE_TLS",
+                                                      "True"))
         self._ssl_cert_path = os.getenv("SMTPD_SSL_CERTS_PATH",
                                         _current_dir.joinpath("certs"))
         self._ssl_cert_files = (
             os.getenv("SMTPD_SSL_CERTIFICATE_FILE", "./cert.pem"),
             os.getenv("SMTPD_SSL_KEY_FILE"))
-        self._use_starttls = strtobool(os.getenv("SMTPD_USE_STARTTLS",
-                                                 "False"))
-        self._use_ssl = (strtobool(os.getenv("SMTPD_USE_SSL", "False"))
-                         or strtobool(os.getenv("SMTPD_USE_TLS", "False")))
+        self._use_starttls = _strtobool(os.getenv("SMTPD_USE_STARTTLS",
+                                                  "False"))
+        self._use_ssl = (_strtobool(os.getenv("SMTPD_USE_SSL", "False"))
+                         or _strtobool(os.getenv("SMTPD_USE_TLS", "False")))
 
     def convert_to_bool(self, value):
         """Consistently convert to bool."""
         if isinstance(value, str):
-            return bool(strtobool(value))
+            return bool(_strtobool(value))
         return bool(value)
 
     @property

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from smtpdfix.configuration import Config
+from smtpdfix.configuration import Config, _strtobool
 
 values = [
     ("host", "mail.localhost", "mail.localhost", str),
@@ -43,6 +43,22 @@ def handler():
         def handle(self, result):
             result.append(True)
     yield Handler()
+
+
+@pytest.mark.parametrize("val", ["y", "yes", "t", "true", "on", "1"])
+def test_strtobool_true(val):
+    assert _strtobool(val) is True
+
+
+@pytest.mark.parametrize("val", ["n", "no", "f", "false", "off", "0"])
+def test_strtobool_false(val):
+    assert _strtobool(val) is False
+
+
+@pytest.mark.parametrize("val", ["-1", "maybe", "error"])
+def test_strtobool_error(val):
+    with pytest.raises(ValueError):
+        assert _strtobool(val) is False
 
 
 def test_init():


### PR DESCRIPTION
Distutils will be removed as of python 3.12 which will break our
use of the distutils.utils.strtobool function.

This commit copies and updates that function to the configuration
module in anticipation of this change.

Closes #114