### PR TITLE
Increase ready timeout

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@
 
 # The number of second the server will attempt to start before raising a
 # TimeoutError.
-# SMTPD_READY_TIMEOUT=5.0
+# SMTPD_READY_TIMEOUT=10.0
 
 # If you're using the out-of-the-box Authenticator you can customize the
 # username and password that are used to login.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Property         | Variable               | Default              | Description
 -----------------|------------------------|----------------------|------------
 `host`           | `SMTPD_HOST`           | `127.0.0.1` or `::1` | The hostname that the fixture will listen on.
 `port`           | `SMTPD_PORT`           | `8025`               | The port that the fixture will listen on.
-`ready_timeout`  | `SMTPD_READY_TIMEOUT`  | `5.0`                | The seconds the server will wait to start before raising a `TimeoutError`.
+`ready_timeout`  | `SMTPD_READY_TIMEOUT`  | `10.0`               | The seconds the server will wait to start before raising a `TimeoutError`.
 `login_username` | `SMTPD_LOGIN_NAME`     | `user`               | Username for default authentication.
 `login_password` | `SMTPD_LOGIN_PASSWORD` | `password`           | Password for default authentication.
 `use_ssl`        | `SMTPD_USE_SSL`        | `False`              | Whether the fixture should use fixed TLS/SSL for transactions. If using smtplib requires that `SMTP_SSL` be used instead of `SMTP`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Release date: TBD
 - Corrects minor error in READMIE.md [Issue #140](https://github.com/bebleo/smtpdfix/issues/140)
 - Fixes a previously unreported bug where self-signed certificates would be rejected if no CA was generated and trusted. Now any certificate file, including the one generated internally, will be trusted.
 - Drops the dependecy on the `distutils` package in preparation for its removal with python 3.12. [Issue #114](https://github.com/bebleo/smtpdfix/issues/114)
+- Updates the `ready_timeout` from five seconds to ten seconds to mitigate issues where the fixture fails to start in time. See [Issue #80](https://github.com/bebleo/smtpdfix/issues/80)
 
 ## Version 0.3.3
 

--- a/smtpdfix/configuration.py
+++ b/smtpdfix/configuration.py
@@ -36,7 +36,7 @@ class Config():
 
         self._host = os.getenv("SMTPD_HOST")
         self._port = int(os.getenv("SMTPD_PORT", 8025))
-        self._ready_timeout = float(os.getenv("SMTPD_READY_TIMEOUT", 5.0))
+        self._ready_timeout = float(os.getenv("SMTPD_READY_TIMEOUT", 10.0))
         self._login_username = os.getenv("SMTPD_LOGIN_NAME", "user")
         self._login_password = os.getenv("SMTPD_LOGIN_PASSWORD", "password")
         self._enforce_auth = _strtobool(os.getenv("SMTPD_ENFORCE_AUTH",

--- a/tests/assets/.test.env
+++ b/tests/assets/.test.env
@@ -5,6 +5,9 @@
 SMTPD_HOST=127.0.0.1
 SMTPD_PORT=5025
 
+# Set the timeout for the server to start.
+SMTPD_READY_TIMEOUT=11.0
+
 # If you're using the out-of-the-box Authenticator you can customize the
 # username and password that are used to login.
 SMTPD_LOGIN_NAME=user


### PR DESCRIPTION
Increase the number of seconds that the server will wait before it
times out with a TimeoutError to mitigate issues with the sockets
not being released.

See #80