### PR TITLE
Add unofficial PyPy 3.9 support

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.9]
 
     steps:
     - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8, pypy-3.9]
         include:
           - os: macos-latest
             python-version: "3.10"
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.10", pypy-3.8]
+        python-version: ["3.7", "3.10", pypy-3.8, pypy-3.9]
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Release date: TBD
 - Drops the dependecy on the `distutils` package in preparation for its removal with python 3.12. [Issue #114](https://github.com/bebleo/smtpdfix/issues/114)
 - Updates the `ready_timeout` from five seconds to ten seconds to mitigate issues where the fixture fails to start in time. See [Issue #80](https://github.com/bebleo/smtpdfix/issues/80)
 - Previously the `AuthController._get_ssl_context.resolve_context` method would return `None` if the `file_` argument was `None`. This will now raise an error instead. The method has been renamed `_resolve_context` to clarify that it should not be considered part of the public API.
+- Adds PyPy 3.9 to CI and `tox.ini` along with appropriate entries in the `minimum\requirements.txt` to reflect that PyPy 3.9 requires cryptography >= 37.0.0. [Issue #166](https://github.com/bebleo/smtpdfix/issurs/166s)
 
 ## Version 0.3.3
 

--- a/requirements/minimum/requirements.txt
+++ b/requirements/minimum/requirements.txt
@@ -1,6 +1,8 @@
 aiosmtpd==1.3.1; python_version<="3.9"
 aiosmtpd==1.4.0; python_version>="3.10"
-cryptography==3.4.4
+cryptography==3.4.4; python_implementation!="PyPy"
+cryptography==3.4.4; python_implementation=="PyPy" and python_version<="3.8"
+cryptography==37.0.0; python_implementation=="PyPy" and python_version>="3.9" # First version for which wheels exist for PyPy39
 pytest==3.9.1; python_version<="3.9"
 pytest==6.2.5; python_version>="3.10"  # Due to an error with assertion rewrites under 3.10
 python-dotenv==0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py{37,38,39,310,py37,py38}, # Standard install & test cpython and pypy (unofficial)
-          py{37,310}-{min,latest},    # Test against the earliest known good, and latest dependencies
-          py{310}-cov,                # Coverage must be 100%
-          py{310}-lint                # Code needs to be pretty!
+envlist = py{37,38,39,310,py37,py38,py39}, # Standard install & test cpython and pypy (unofficial)
+          py{37,310}-{min,latest},         # Test against the earliest known good, and latest dependencies
+          py{310}-cov,                     # Coverage must be 100%
+          py{310}-lint                     # Code needs to be pretty!
 
 [testenv]
 passenv = PYTHON_VERSION
@@ -12,13 +12,13 @@ deps = pytest-timeout
        latest: -r requirements/latest/requirements.txt
 commands = pytest -p no:smtpd {posargs}
 
-[testenv:py{37,38,39,310,py37,py38}-pre]
+[testenv:py{37,38,39,310,py37,py38,py39}-pre]
 install_command = pip install --pre {opts} {packages}
 
-[testenv:py{37,38,39,310,py37,py38}-cov]
+[testenv:py{37,38,39,310,py37,py38,py39}-cov]
 commands = pytest -p no:smtpd --cov --no-cov-on-fail --cov-fail-under=100 {posargs}
 
-[testenv:py{37,38,39,310,py37,py38}-lint]
+[testenv:py{37,38,39,310,py37,py38,py39}-lint]
 deps = flake8
        isort
 commands = isort --check .


### PR DESCRIPTION
Issues with cryptography < 37.0.0 prevent install when using >= pypy-3.9

This adds:
- Tox tests against pypy39
- Pypy-3.9 to the python-versions matrix in Github action workflows
- an entry in the minimum/requirements.txt for cryptography with
  PyPy 3.9 and greater.

Closes #166 