### PR TITLE
Drop pyproject toml

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.9]
 
     steps:
     - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8, pypy-3.9]
         include:
           - os: macos-latest
             python-version: "3.10"
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.10", pypy-3.8]
+        python-version: ["3.7", "3.10", pypy-3.8, pypy-3.9]
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py{37,38,39,310,py37,py38}, # Standard install & test cpython and pypy (unofficial)
-          py{37,310}-{min,latest},    # Test against the earliest known good, and latest dependencies
-          py{310}-cov,                # Coverage must be 100%
-          py{310}-lint                # Code needs to be pretty!
+envlist = py{37,38,39,310,py37,py38,py39}, # Standard install & test cpython and pypy (unofficial)
+          py{37,310}-{min,latest},         # Test against the earliest known good, and latest dependencies
+          py{310}-cov,                     # Coverage must be 100%
+          py{310}-lint                     # Code needs to be pretty!
 
 [testenv]
 passenv = PYTHON_VERSION
@@ -12,13 +12,13 @@ deps = pytest-timeout
        latest: -r requirements/latest/requirements.txt
 commands = pytest -p no:smtpd {posargs}
 
-[testenv:py{37,38,39,310,py37,py38}-pre]
+[testenv:py{37,38,39,310,py37,py38,py39}-pre]
 install_command = pip install --pre {opts} {packages}
 
-[testenv:py{37,38,39,310,py37,py38}-cov]
+[testenv:py{37,38,39,310,py37,py38,py39}-cov]
 commands = pytest -p no:smtpd --cov --no-cov-on-fail --cov-fail-under=100 {posargs}
 
-[testenv:py{37,38,39,310,py37,py38}-lint]
+[testenv:py{37,38,39,310,py37,py38,py39}-lint]
 deps = flake8
        isort
 commands = isort --check .


### PR DESCRIPTION
An experiment in pypy3 support and whether dropping `pyproject.toml` will enable the package to install.