### PR TITLE
Remove generate certs from all

### DIFF
--- a/requirements/latest/requirements.txt
+++ b/requirements/latest/requirements.txt
@@ -1,4 +1,4 @@
 aiosmtpd==1.4.2
-cryptography==36.0.2
-pytest==7.1.1
+cryptography==37.0.1
+pytest==7.1.2
 python-dotenv==0.20.0

--- a/smtpdfix/__init__.py
+++ b/smtpdfix/__init__.py
@@ -3,7 +3,6 @@ __all__ = (
     "Authenticator",
     "AuthMessage",
     "Config",
-    "generate_certs",
     "smtpd",
     "SMTPDFix",
 )


### PR DESCRIPTION
`generate_certs` has been deprecated, but was still in
__all__. This removes it to properly deprecate the
method.