### PR TITLE
Mark authenticator as abstract

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,8 @@ Release date: TBD
 - Drops the dependecy on the `distutils` package in preparation for its removal with python 3.12. [Issue #114](https://github.com/bebleo/smtpdfix/issues/114)
 - Updates the `ready_timeout` from five seconds to ten seconds to mitigate issues where the fixture fails to start in time. See [Issue #80](https://github.com/bebleo/smtpdfix/issues/80)
 - Previously the `AuthController._get_ssl_context.resolve_context` method would return `None` if the `file_` argument was `None`. This will now raise an error instead. The method has been renamed `_resolve_context` to clarify that it should not be considered part of the public API.
-- Adds PyPy 3.9 to CI and `tox.ini` along with appropriate entries in the `minimum\requirements.txt` to reflect that PyPy 3.9 requires cryptography >= 37.0.0. [Issue #166](https://github.com/bebleo/smtpdfix/issurs/166s)
+- Adds PyPy 3.9 to CI and `tox.ini` along with appropriate entries in the `minimum\requirements.txt` to reflect that PyPy 3.9 requires cryptography >= 37.0.0. [Issue #166](https://github.com/bebleo/smtpdfix/issues/166)
+- Mark the Authenticator class as being abstract by setting the metaclass to be `abc.ABCMeta` and decorating the methods with `@abc.abstractmethod`
 
 ## Version 0.3.3
 

--- a/requirements/latest/requirements.txt
+++ b/requirements/latest/requirements.txt
@@ -1,4 +1,4 @@
 aiosmtpd==1.4.2
-cryptography==36.0.2
-pytest==7.1.1
+cryptography==37.0.1
+pytest==7.1.2
 python-dotenv==0.20.0

--- a/smtpdfix/authenticator.py
+++ b/smtpdfix/authenticator.py
@@ -1,8 +1,13 @@
-class Authenticator():
+from abc import ABCMeta, abstractmethod
+
+
+class Authenticator(metaclass=ABCMeta):
+    @abstractmethod
     def validate(self, username: str, password: str) -> bool:
         """Validate that the passward authenticates the username."""
         raise NotImplementedError()  # pragma: no cover
 
+    @abstractmethod
     def verify(self, username: str) -> bool:
         """Method to verify that an address or username is correct.
 
@@ -16,6 +21,7 @@ class Authenticator():
         """
         raise NotImplementedError()  # pragma: no cover
 
+    @abstractmethod
     def get_password(self, username: str) -> str:
         """Returns the password for a given username."""
         raise NotImplementedError()  # pragma: no cover

--- a/smtpdfix/fixture.py
+++ b/smtpdfix/fixture.py
@@ -28,6 +28,9 @@ class _Authenticator(Authenticator):
         log.debug("Validating username and password failed")
         return False
 
+    def verify(self, username: str) -> bool:
+        return super().verify(username)
+
     def get_password(self, username: Optional[str]) -> str:
         return self.config.login_password
 

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from smtpdfix import Config
+from smtpdfix.fixture import _Authenticator
 
 
 def encode(message):
@@ -205,3 +206,19 @@ def test_monkeypatch(monkeypatch, smtpd):
         code, repl = client.docmd("DATA", "")
         assert code == 530
         assert repl.startswith(b"5.7.0 Authentication required")
+
+
+class TestDefaultAuthenticator:
+    _config = Config()
+    _auth = _Authenticator(_config)
+
+    def test_validate(cls, user):
+        assert cls._auth.validate(user.username, user.password)
+
+    def test_verify(cls, user):
+        with pytest.raises(NotImplementedError):
+            cls._auth.verify(user.username)
+
+    def test_get_password(cls, user):
+        password = cls._auth.get_password(user.username)
+        assert password == user.password


### PR DESCRIPTION
The `authenticator` class was designed to be abstract, but
not marked as such. This now uses `abc` to mark it as an
Abstract Base Class and the methods as `@abstractmethod`.