### PR TITLE
Use cache for dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
       uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -71,6 +72,7 @@ jobs:
       uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -101,6 +103,7 @@ jobs:
       uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Implements the cache feature for dependencies in
Github Actions with the aim of speeding up tests.