### PR TITLE
Generate key and cert when hostname does not resolve to IP

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Release date: TBD
 - Previously the `AuthController._get_ssl_context.resolve_context` method would return `None` if the `file_` argument was `None`. This will now raise an error instead. The method has been renamed `_resolve_context` to clarify that it should not be considered part of the public API.
 - Adds PyPy 3.9 to CI and `tox.ini` along with appropriate entries in the `minimum\requirements.txt` to reflect that PyPy 3.9 requires cryptography >= 37.0.0. [Issue #166](https://github.com/bebleo/smtpdfix/issues/166)
 - Mark the Authenticator class as being abstract by setting the metaclass to be `abc.ABCMeta` and decorating the methods with `@abc.abstractmethod`
+- On systems where the hostname does not resolve to an IP address the key and certificate will now generate. [Issue #195](https://github.com/bebleo/smtpdfix/195) reported by [Andreas Motl (@amotl)](https://github.com/amotl).
 
 ## Version 0.3.3
 

--- a/tests/test_smtpdfix.py
+++ b/tests/test_smtpdfix.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from smtplib import SMTP
+from typing import Any
 
 from smtpdfix import SMTPDFix
 
@@ -7,3 +9,19 @@ def test_smtpdfix(msg):
     with SMTPDFix() as server, SMTP(server.hostname, server.port) as client:
         client.send_message(msg)
         assert len(server.messages) == 1
+
+
+def test_misconfigured_socket(monkeypatch, tmp_path_factory):
+    # As reported in #195 a misconfigured system will raise an error if
+    # the hostname won't resolve to an IP address
+    def raise_GAIError(*args: Any) -> None:
+        from socket import gaierror
+        raise gaierror("[Errno 8] nodename nor servname "
+                       "provided, or not known")
+    monkeypatch.setattr("socket.gethostbyname", raise_GAIError)
+
+    from smtpdfix.certs import _generate_certs
+    path = tmp_path_factory.mktemp("certs")
+    _generate_certs(path)
+
+    assert Path.joinpath(path, "cert.pem").is_file()


### PR DESCRIPTION
Fixes the situation where on misconfigured systems the hostname for a system doesn't resolve to an IP using `socket.getbyhostname`.

Fixes #195 