### PR TITLE
Fix StartTLS on python 3.11

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445 # v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.1.0
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.1.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445 # v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.1.0
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.1.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -64,7 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445 # v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.1.0
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.1.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -95,7 +95,7 @@ jobs:
     steps:
     - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445 # v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.1.0
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.1.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", pypy-3.7, pypy-3.8, pypy-3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", pypy-3.7, pypy-3.8, pypy-3.9]
         include:
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11-dev"
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11-dev"
     timeout-minutes: 10
 
     steps:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7","3.10"]
+        python-version: ["3.7","3.11-dev"]
     timeout-minutes: 5
 
     steps:
@@ -84,12 +84,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.10", pypy-3.8, pypy-3.9]
+        python-version: ["3.7", "3.11-dev", pypy-3.8, pypy-3.9]
         include:
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11-dev"
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11-dev"
     timeout-minutes: 5
 
     steps:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 
-## Unreleased changes
+## Version 0.4.1
 
-Release date: TBD
+Release date: 2022-10-29
+
+- Adds support for python 3.11.
+- Corrects an error related to `aiomsmtpd` that prevented StartTLS commands from working correctly. [Issue #227](https://github.com/bebleo/smtpdfix/227)
 
 ## Version 0.4.0
 
@@ -10,7 +13,7 @@ Release date: 2022-09-05
 
 - Support for python 3.6 has been dropped and python 3.7 or later is required. [Issue #113](https://github.com/bebleo/smtpdfix/issues/113)
 - `generate_certs` has been removed from the public API. [Issue #95](https://github.com/bebleo/smtpdfix/issues/95)
-- Corrects minor error in READMIE.md [Issue #140](https://github.com/bebleo/smtpdfix/issues/140)
+- Corrects minor error in README.md [Issue #140](https://github.com/bebleo/smtpdfix/issues/140)
 - Fixes a previously unreported bug where self-signed certificates would be rejected if no CA was generated and trusted. Now any certificate file, including the one generated internally, will be trusted.
 - Drops the dependecy on the `distutils` package in preparation for its removal with python 3.12. [Issue #114](https://github.com/bebleo/smtpdfix/issues/114)
 - Updates the `ready_timeout` from five seconds to ten seconds to mitigate issues where the fixture fails to start in time. See [Issue #80](https://github.com/bebleo/smtpdfix/issues/80)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 project_urls =
@@ -44,6 +45,7 @@ pytest11 =
 dev =
     flake8
     isort
+    pytest-asyncio
     pytest-cov
     pytest-timeout
     tox

--- a/smtpdfix/controller.py
+++ b/smtpdfix/controller.py
@@ -9,12 +9,15 @@ from ssl import CERT_OPTIONAL, Purpose, SSLContext, create_default_context
 from typing import Any, List, Optional
 
 from aiosmtpd.controller import Controller, get_localhost
-from aiosmtpd.smtp import SMTP
 
 from .authenticator import Authenticator
 from .configuration import Config
 from .handlers import AuthMessage
+from .smtp import SMTP
 from .typing import AsyncServer, PathType, ServerCoroutine
+
+# from aiosmtpd.smtp import SMTP
+
 
 log = logging.getLogger(__name__)
 

--- a/smtpdfix/smtp.py
+++ b/smtpdfix/smtp.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from aiosmtpd.smtp import SMTP as _SMTP
+from aiosmtpd.smtp import TLSSetupException, syntax
+
+
+class SMTP(_SMTP):
+
+    @syntax('STARTTLS', when='tls_context')
+    async def smtp_STARTTLS(self, arg: str) -> None:
+        if arg:
+            await self.push('501 Syntax: STARTTLS')
+            return
+        if not self.tls_context:
+            await self.push('454 TLS not available')
+            return
+        await self.push('220 Ready to start TLS')
+
+        try:
+            self._original_transport = self.transport
+            new_transport = await self.loop.start_tls(
+                                       transport=self.transport,
+                                       protocol=self,
+                                       sslcontext=self.tls_context,
+                                       server_side=True,
+                                       ssl_handshake_timeout=5.0)
+            self._reader._transport = new_transport
+            self._writer._transport = new_transport
+            self._tls_protocol = new_transport.get_protocol()
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            raise TLSSetupException() from error

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -1,13 +1,86 @@
-from smtplib import SMTP
+import asyncio
+from asyncio import CancelledError, Future
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 
+@pytest.fixture
+def future() -> Any:
+    mock_loop = MagicMock()
+    f: asyncio.Future[bool] = Future(loop=mock_loop)
+    f.set_result(True)
+    return f
+
+
 @pytest.mark.parametrize("cmd", ["DATA", "MAIL", "RCPT"])
-def test_auth_first(cmd, smtpd):
+def test_auth_first(cmd: str, smtpd: Any) -> None:
     smtpd.config.enforce_auth = True
+    from smtplib import SMTP
     with SMTP(smtpd.hostname, smtpd.port) as client:
         client.ehlo()
         code, repl = client.docmd(cmd, "")
         assert code == 530
         assert repl.startswith(b"5.7.0 Authentication required")
+
+
+@pytest.mark.asyncio
+@patch("smtpdfix.handlers.AuthMessage")
+async def test_starttls_with_arg(mock_AuthMessage: Mock, future: Any) -> None:
+    from smtpdfix.smtp import SMTP as _SMTP
+    smtpd: _SMTP = _SMTP(mock_AuthMessage)
+    with patch.object(smtpd, "push", return_value=future) as mock_push:
+        await smtpd.smtp_STARTTLS("arg")
+        mock_push.assert_called_with("501 Syntax: STARTTLS")
+
+
+@pytest.mark.asyncio
+@patch("smtpdfix.handlers.AuthMessage")
+async def test_starttls_no_context(mock_AuthMessage: Mock,
+                                   future: Any) -> None:
+    from smtpdfix.smtp import SMTP as _SMTP
+    smtpd: _SMTP = _SMTP(mock_AuthMessage)
+    with patch.object(smtpd, "push", return_value=future) as mock_push:
+        await smtpd.smtp_STARTTLS(None)
+        mock_push.assert_called_with('454 TLS not available')
+
+
+@pytest.mark.asyncio
+@patch("ssl.SSLContext")
+@patch("smtpdfix.handlers.AuthMessage")
+async def test_starttls_CancelledError(mock_AuthMessage: Mock,
+                                       mock_SSLContext: Mock,
+                                       future: Any) -> None:
+    from smtpdfix.smtp import SMTP as _SMTP
+
+    mock_loop = Mock()
+    mock_loop.start_tls.side_effect = CancelledError()
+    smtpd: _SMTP = _SMTP(mock_AuthMessage,
+                         tls_context=mock_SSLContext,
+                         loop=mock_loop)
+    with patch.object(smtpd, "push", return_value=future) as mock_push:
+        with pytest.raises(CancelledError):
+            await smtpd.smtp_STARTTLS(None)
+        mock_push.assert_called_once_with('220 Ready to start TLS')
+
+
+@pytest.mark.asyncio
+@patch("ssl.SSLContext")
+@patch("smtpdfix.handlers.AuthMessage")
+async def test_starttls_Exception(mock_AuthMessage: Mock,
+                                  mock_SSLContext: Mock,
+                                  future: Any) -> None:
+    from aiosmtpd.smtp import TLSSetupException
+
+    from smtpdfix.smtp import SMTP as _SMTP
+
+    mock_loop = Mock()
+    mock_loop.start_tls.side_effect = Exception()
+    smtpd: _SMTP = _SMTP(mock_AuthMessage,
+                         tls_context=mock_SSLContext,
+                         loop=mock_loop)
+    with patch.object(smtpd, "push", return_value=future) as mock_push:
+        with pytest.raises(TLSSetupException):
+            await smtpd.smtp_STARTTLS(None)
+        mock_push.assert_called_once_with('220 Ready to start TLS')

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py{37,38,39,310,py37,py38,py39}, # Standard install & test cpython and pypy (unofficial)
-          py{37,310}-{min,latest},         # Test against the earliest known good, and latest dependencies
-          py{310}-cov,                     # Coverage must be 100%
-          py{310}-lint                     # Code needs to be pretty!
-          py{37}-typing                    # Ensure code is typed
+envlist = py{37,38,39,310,311,py37,py38,py39}, # Standard install & test cpython and pypy (unofficial)
+          py{37,311}-{min,latest},             # Test against the earliest known good, and latest dependencies
+          py{311}-cov,                         # Coverage must be 100%
+          py{311}-lint                         # Code needs to be pretty!
+          py{37}-typing                        # Ensure code is typed
 
 
 [testenv]
@@ -14,18 +14,18 @@ deps = pytest-timeout
        latest: -r requirements/latest/requirements.txt
 commands = pytest -p no:smtpd {posargs}
 
-[testenv:py{37,38,39,310,py37,py38,py39}-pre]
+[testenv:py{37,38,39,310,311,py37,py38,py39}-pre]
 install_command = pip install --pre {opts} {packages}
 
-[testenv:py{37,38,39,310,py37,py38,py39}-cov]
+[testenv:py{37,38,39,310,311,py37,py38,py39}-cov]
 commands = pytest -p no:smtpd --cov --no-cov-on-fail --cov-fail-under=100 {posargs}
 
-[testenv:py{37,38,39,310,py37,py38,py39}-lint]
+[testenv:py{37,38,39,310,311,py37,py38,py39}-lint]
 deps = flake8
        isort
 commands = isort --check .
            flake8 .
 
-[testenv:py{37,38,39,310,py37,py38}-typing]
+[testenv:py{37,38,39,310,311,py37,py38}-typing]
 deps = mypy
 commands = mypy

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = py{37,38,39,310,311,py37,py38,py39}, # Standard install & test cpython
 [testenv]
 passenv = PYTHON_VERSION
 deps = pytest-timeout
+       pytest-asyncio
        cov: pytest-cov
        min: -r requirements/minimum/requirements.txt
        latest: -r requirements/latest/requirements.txt


### PR DESCRIPTION
STARTTLS fails on Python 3.11 due to bugs in the underlying aiosmtpd code.

Specifically:
+ Adds support and tests for python 3.11
+ Adds pytest-asyncio to dependencies
+ Patches the SMTP Protocol in aiosmtpd and updates the controller
+ Adds tests

Fixes #227