### PR TITLE
Remove SMTP from public API

### DIFF
--- a/smtpdfix/controller.py
+++ b/smtpdfix/controller.py
@@ -13,7 +13,7 @@ from aiosmtpd.controller import Controller, get_localhost
 from .authenticator import Authenticator
 from .configuration import Config
 from .handlers import AuthMessage
-from .smtp import SMTP
+from .smtp import _SMTP
 from .typing import AsyncServer, PathType, ServerCoroutine
 
 # from aiosmtpd.smtp import SMTP
@@ -72,16 +72,16 @@ class AuthController(Controller):
         self.config.OnChanged += self.reset
         log.info(f"SMTPDFix running on {self.hostname}:{self.port}")
 
-    def factory(self) -> SMTP:
+    def factory(self) -> _SMTP:
         use_starttls = self.config.use_starttls
         context = self._get_ssl_context() if use_starttls else None
 
-        return SMTP(handler=self.handler,
-                    require_starttls=self.config.use_starttls,
-                    auth_required=self.config.enforce_auth,
-                    auth_require_tls=self.config.auth_require_tls,
-                    tls_context=context,
-                    authenticator=self._authenticator)
+        return _SMTP(handler=self.handler,
+                     require_starttls=self.config.use_starttls,
+                     auth_required=self.config.enforce_auth,
+                     auth_require_tls=self.config.auth_require_tls,
+                     tls_context=context,
+                     authenticator=self._authenticator)
 
     def _get_ssl_context(self) -> SSLContext:
         if self._ssl_context is not None:

--- a/smtpdfix/smtp.py
+++ b/smtpdfix/smtp.py
@@ -1,10 +1,9 @@
 import asyncio
 
-from aiosmtpd.smtp import SMTP as _SMTP
-from aiosmtpd.smtp import TLSSetupException, syntax
+from aiosmtpd.smtp import SMTP, TLSSetupException, syntax
 
 
-class SMTP(_SMTP):
+class _SMTP(SMTP):
 
     @syntax('STARTTLS', when='tls_context')
     async def smtp_STARTTLS(self, arg: str) -> None:

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -28,7 +28,7 @@ def test_auth_first(cmd: str, smtpd: Any) -> None:
 @pytest.mark.asyncio
 @patch("smtpdfix.handlers.AuthMessage")
 async def test_starttls_with_arg(mock_AuthMessage: Mock, future: Any) -> None:
-    from smtpdfix.smtp import SMTP as _SMTP
+    from smtpdfix.smtp import _SMTP
     smtpd: _SMTP = _SMTP(mock_AuthMessage)
     with patch.object(smtpd, "push", return_value=future) as mock_push:
         await smtpd.smtp_STARTTLS("arg")
@@ -39,7 +39,7 @@ async def test_starttls_with_arg(mock_AuthMessage: Mock, future: Any) -> None:
 @patch("smtpdfix.handlers.AuthMessage")
 async def test_starttls_no_context(mock_AuthMessage: Mock,
                                    future: Any) -> None:
-    from smtpdfix.smtp import SMTP as _SMTP
+    from smtpdfix.smtp import _SMTP
     smtpd: _SMTP = _SMTP(mock_AuthMessage)
     with patch.object(smtpd, "push", return_value=future) as mock_push:
         await smtpd.smtp_STARTTLS(None)
@@ -52,7 +52,7 @@ async def test_starttls_no_context(mock_AuthMessage: Mock,
 async def test_starttls_CancelledError(mock_AuthMessage: Mock,
                                        mock_SSLContext: Mock,
                                        future: Any) -> None:
-    from smtpdfix.smtp import SMTP as _SMTP
+    from smtpdfix.smtp import _SMTP
 
     mock_loop = Mock()
     mock_loop.start_tls.side_effect = CancelledError()
@@ -73,7 +73,7 @@ async def test_starttls_Exception(mock_AuthMessage: Mock,
                                   future: Any) -> None:
     from aiosmtpd.smtp import TLSSetupException
 
-    from smtpdfix.smtp import SMTP as _SMTP
+    from smtpdfix.smtp import _SMTP
 
     mock_loop = Mock()
     mock_loop.start_tls.side_effect = Exception()


### PR DESCRIPTION
The patch for issues with STARTTLS lead to the creation of a new SMTP class implementing the protocol. This commit renames it to _SMTP to clarify that it should not be considered as part of the public API.