### PR TITLE
Pin cryptography version for PyPy

### DIFF
--- a/requirements/latest/requirements.txt
+++ b/requirements/latest/requirements.txt
@@ -1,5 +1,7 @@
 aiosmtpd==1.4.4.post2
-cryptography==39.0.2
+cryptography==39.0.2; python_implementation=="PyPy" and python_version<="3.7"
+cryptography==40.0.1; python_implementation=="PyPy" and python_version>="3.8"
+cryptography==40.0.1; python_implementation!="PyPy"
 pytest==7.2.2
 python-dotenv==0.21.1; python_version<="3.7"
 python-dotenv==1.0.0; python_version>="3.8"

--- a/requirements/minimum/requirements.txt
+++ b/requirements/minimum/requirements.txt
@@ -1,9 +1,5 @@
 aiosmtpd==1.3.1; python_version<="3.9"
 aiosmtpd==1.4.0; python_version>="3.10"
-# cryptography==3.4.4; python_implementation!="PyPy"
-# cryptography==3.4.4; python_implementation=="PyPy" and python_version<="3.7"
-# cryptography==36.0.0; python_implementation=="PyPy" and python_version=="3.8"
-# cryptography==38.0.3; python_implementation=="PyPy" and python_version>="3.9" # To fix a security issue with 37.0.0 to 38.0.2
 cryptography==39.0.1;
 pytest==6.2.0; python_version<="3.9"
 pytest==6.2.5; python_version>="3.10"  # Due to an error with assertion rewrites under 3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,8 @@ packages = find:
 include_package_data = True
 install_requires =
     aiosmtpd
-    cryptography
+    cryptography >= 39.0.1;python_implementation!="PyPy"
+    cryptography ~= 39.0.1;python_implementation=="PyPy"
     pytest
     python-dotenv
 python_requires = >=3.7

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps = pytest-timeout
        cov: pytest-cov
        min: -r requirements/minimum/requirements.txt
        latest: -r requirements/latest/requirements.txt
-install_command = pip install --upgrade {opts} {packages}
+install_command = pip install {opts} {packages}
 commands = pytest -p no:smtpd {posargs}
 
 [testenv:py{37,38,39,310,311,py37,py38,py39}-pre]


### PR DESCRIPTION
Fixes issues that cause failures when running under PyPy3.7 to PyPy3.9 relating to changes with cryptography starting with version 40.0.0

Pins cryptography to major version 39 for PyPy implementations.