### PR TITLE
User a random available port instead of 8025 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Configuration is handled through properties in the `config` of the fixture and a
 Property         | Variable               | Default              | Description
 -----------------|------------------------|----------------------|------------
 `host`           | `SMTPD_HOST`           | `127.0.0.1` or `::1` | The hostname that the fixture will listen on.
-`port`           | `SMTPD_PORT`           | `8025`               | The port that the fixture will listen on.
+`port`           | `SMTPD_PORT`           | `a random free port` | The port that the fixture will listen on.
 `ready_timeout`  | `SMTPD_READY_TIMEOUT`  | `10.0`               | The seconds the server will wait to start before raising a `TimeoutError`.
 `login_username` | `SMTPD_LOGIN_NAME`     | `user`               | Username for default authentication.
 `login_password` | `SMTPD_LOGIN_PASSWORD` | `password`           | Password for default authentication.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Release date: TBD
 Previously `smtpdfix` would load a `.env` file automatically using `python-dotenv`. This behaviour has been corrected and .env files must be loaded separately.
 
 - As of version 0.5.0 Smtpdfix no longer uses `python-dotenv` to load a `.env` file by default. [Issue #274](https://github.com/bebleo/smtpdfix/274) reported by [Emmanuel Belair (@e-belair)](https://github.com/e-belair)
+- A random unused port is used instead of the default 8025 port. [Issue #820](https://github.com/bebleo/smtpdfix/issues/280) reported by [Éloi Rivard](https://github.com/azmeuk)
 
 ## Version 0.4.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     aiosmtpd
     cryptography;python_implementation!="PyPy"
     cryptography >= 39.0.1, < 40.0.0;python_implementation=="PyPy"
+    portpicker
     pytest
 python_requires = >=3.7
 
@@ -87,3 +88,6 @@ warn_unused_ignores = True
 warn_return_any = True
 # warn_unreachable = True
 follow_imports = skip
+
+[mypy-portpicker.*]
+ignore_missing_imports = True

--- a/smtpdfix/configuration.py
+++ b/smtpdfix/configuration.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 from typing import Any, Optional, Tuple, Union
 
+import portpicker
+
 from .event_handler import EventHandler
 from .typing import PathType
 
@@ -32,7 +34,9 @@ class Config():
         self.OnChanged = EventHandler()
 
         self._host = os.getenv("SMTPD_HOST")
-        self._port = int(os.getenv("SMTPD_PORT", 8025))
+        self._port = int(
+            os.getenv("SMTPD_PORT", portpicker.pick_unused_port())
+        )
         self._ready_timeout = float(os.getenv("SMTPD_READY_TIMEOUT", 10.0))
         self._login_username = os.getenv("SMTPD_LOGIN_NAME", "user")
         self._login_password = os.getenv("SMTPD_LOGIN_PASSWORD", "password")

--- a/smtpdfix/fixture.py
+++ b/smtpdfix/fixture.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any, Generator, Optional
 
+import portpicker
 import pytest
 
 from .authenticator import Authenticator
@@ -38,10 +39,14 @@ class _Authenticator(Authenticator):
 class SMTPDFix():
     def __init__(self,
                  hostname: Optional[str] = None,
-                 port: int = 8025,
+                 port: Optional[int] = None,
                  config: Optional[Config] = None) -> None:
         self.hostname = hostname
-        self.port = int(port) if port is not None else 8025
+        self.port = (
+            int(port)
+            if port is not None
+            else portpicker.pick_unused_port()
+        )
         self.config = config or Config()
 
     def __enter__(self) -> AuthController:


### PR DESCRIPTION
Fixes #280, so smptdfix can be used with pytest-xdist or `tox -p`