### PR TITLE
Replace deprecated datetime.utcnow()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Release Date: TBD
 
 - Testing against PyPy in tox is now against versions PyPy 3.9 and PyPy 3.10.
 - Stop tox installing when running on GitHub CI.
+- Removes deprecated `datetime.utcnow()`. [Issue #338](https://github.com/bebleo/smtpdfix/issues/338).
 
 ## Version 0.5.1
 

--- a/smtpdfix/certs.py
+++ b/smtpdfix/certs.py
@@ -1,6 +1,6 @@
 import logging
 import socket
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import ip_address
 from pathlib import Path
 from typing import Union
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 def _generate_certs(path: Union[Path, str],
-                    days: int = 3652,
+                    days: int = 365,
                     key_size: int = 2048,
                     separate_key: bool = False) -> None:
     # DO NOT USE THIS FOR ANYTHING PRODUCTION RELATED, EVER!
@@ -63,8 +63,8 @@ def _generate_certs(path: Union[Path, str],
             .issuer_name(subject)
             .subject_name(subject)
             .serial_number(random_serial_number())
-            .not_valid_before(datetime.utcnow())
-            .not_valid_after(datetime.utcnow() + timedelta(days=days))
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=days))
             .add_extension(SubjectAlternativeName(alt_names), critical=False)
             .public_key(key.public_key())
             .add_extension(constraints, critical=False)


### PR DESCRIPTION
As of python 3.12 datetime.utcnow() has been deprecated and this commit replaces that call with the reccomended alternative datetime.now(timezone.utc).

Closes #338