### PR TITLE
Remove obsolete reference to ssl_certs_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,21 +127,11 @@ Property         | Variable               | Default              | Description
 `use_ssl`        | `SMTPD_USE_SSL`        | `False`              | Whether the fixture should use fixed TLS/SSL for transactions. If using smtplib requires that `SMTP_SSL` be used instead of `SMTP`.
 `use_starttls`   | `SMTPD_USE_STARTTLS`   | `False`              | Whether the fixture should use StartTLS to encrypt the connections. If using `smtplib` requires that `SMTP.starttls()` is called before other commands are issued. Overrides `use_tls` as the preferred method for securing communications with the client.
 `enforce_auth`   | `SMTPD_ENFORCE_AUTH`   | `False`              | If set to true then the fixture refuses MAIL, RCPT, DATA commands until authentication is completed.
-`ssl_cert_path`  | `SMTPD_SSL_CERTS_PATH` | `./certs/`           | The path to the key and certificate in PEM format for encryption with SSL/TLS or StartTLS.
 `ssl_cert_files` | `SMTPD_SSL_CERT_FILE` and `SMTPD_SSL_KEY_FILE` | `("cert.pem", None)` | A tuple of the path for the certificate file and key file in PEM format. See [Resolving certificate and key paths](#resolving-certificate-and-key-paths) for more details.
 
-### Resolving certificate and key paths
+### Setting a custom SSL Certificate
 
-In order to resolve the certificate and key paths for the SSL/TLS context SMTPDFix does the following:
-
-1. On initialization of a `smtpdfix.Config` the `ssl_cert_path` is set by the `SMTPD_SSL_CERTS_PATH` environment variable and the `ssl_cert_files` is set to a tuple of `(SMTPD_SSL_CERT_FILE and SMTPD_SSL_KEY_FILE)`. If the environment variables are not set the deafults are used.
-2. If an SSL Context is needed, when the `smptdfix.AuthController` is initialized it will attempt to find the files in the following sequence for both the certificate file and the key file:
-   1. If the value in `ssl_cert_files` is `None` then `None` is returned. Setting the key file to be none assumes that it has been included in the certificate file.
-   2. If the value in `ssl_cert_files` is a valid path to a file then this is returned.
-   3. `ssl_cert_path` and the value from `ssl_cert_files` are joined and returned if it a valid path to a file.
-   4. A `FileNotFoundError` is raised.
-
-An example, assuming that the certificate and key are written in a single PEM file located at `./certificates/localhost.cert.pem` would be:
+Assuming that the certificate and key are written in a single PEM file located at `./certificates/localhost.cert.pem` the following example will use the certificate for SSL encryption:
 
 ```python
 from smtplib import STMP_SSL

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Release Date: TBD
 
+- Obsolete refences to `Config.SSL_Cert_Path` removed from the public API. [Issue #392](https://github.com/bebleo/smtpdfix/392) reported by [Holly Evans (@holly-evans)](https://github.com/holly-evans)
+
 ## Version 0.5.2
 
 Release Date: 2024-04-21


### PR DESCRIPTION
An obsolete reference existed in the README to ssl_certs_path that was removed in version 0.5.2.

- reference removed in the table of config properties
- removed explanation of how the certificates are loaded and the order of precedence since it is now redundant.

Closes #392