### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ cython_debug/
 
 # VS Code
 .vscode/
+package-lock.json


### PR DESCRIPTION
Adds redundant package-lock.json to the .gitignore file under the VS Code section.