### PR TITLE
Refactor GitHub Actions workflow to remove MacOS workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,11 +61,11 @@ jobs:
     - name: Turn off TLS verfication
       if: ${{ matrix.os == 'macos-13'}}
       run: |
-        export GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY=1
-      #   # Make "localhost" DNS entry available; see https://github.com/actions/runner-images/issues/6383
-      #   # sudo networksetup -setdnsservers Ethernet 9.9.9.9
-      #   echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      #   echo `sudo lsof -PiTCP -sTCP:LISTEN`
+        # export GITHUB_ACTIONS_RUNNER_TLS_NO_VERIFY=1
+        # Make "localhost" DNS entry available; see https://github.com/actions/runner-images/issues/6383
+        # sudo networksetup -setdnsservers Ethernet 9.9.9.9
+        echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+        echo `sudo lsof -PiTCP -sTCP:LISTEN`
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -137,6 +137,7 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -p no:smtpd
+
 
 
 


### PR DESCRIPTION
Removes a workaround for MacOS DNS on the GitHub MacOS VMs that appears to be failing.