### PR TITLE
Drop end of life python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.14", pypy-3.11]
+        python-version: ["3.10", "3.14", pypy-3.11]
     timeout-minutes: 5
 
     steps:
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.13", pypy-3.11]
+        python-version: ["3.10", "3.14", pypy-3.11]
     timeout-minutes: 5
 
     steps:
@@ -137,8 +137,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -p no:smtpd
-
-
-
-
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -13,16 +13,16 @@ repos:
     -   id: debug-statements
     -   id: detect-private-key
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
     -   id: isort
         name: isort (python)
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.2
+    rev: 7.3.0
     hooks:
     -   id: flake8

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased Changes
+
+Release Date: TBD
+
+- Support for Python versions 3.8 and 3.9 dropped. Minimum supported version is Python 3.10.
+
 ## Version 0.5.3
 
 Release Date: 2025-11-20

--- a/requirements/minimum/requirements.txt
+++ b/requirements/minimum/requirements.txt
@@ -1,9 +1,8 @@
 aiosmtpd==1.4.6
 cryptography==44.0.2;
 portpicker==1.1.0
-pytest==6.2.0; python_version<="3.9"
-pytest==6.2.5; python_version>="3.10" and python_version<="3.13"  # Due to an error with assertion rewrites under 3.10
+pytest==6.2.5; python_version<="3.13"  # Due to an error with assertion rewrites under 3.10
 pytest==7.3.2; python_version>="3.14"
 # Test fixtures
-pytest-asyncio==0.11.0; python_version>="3.8"
+pytest-asyncio==0.11.0
 pytest-timeout==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -38,7 +36,7 @@ install_requires =
     cryptography
     portpicker
     pytest
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.entry_points]
 pytest11 =
@@ -77,7 +75,7 @@ exclude = env,venv,.venv,.tox,lib,bin
 
 [mypy]
 files = smtpdfix
-python_version = 3.8
+python_version = 3.10
 # show_error_codes = True
 # allow_redefinition = True
 disallow_any_generics = True

--- a/smtpdfix/__init__.py
+++ b/smtpdfix/__init__.py
@@ -6,7 +6,7 @@ __all__ = (
     "smtpd",
     "SMTPDFix",
 )
-__version__ = "0.5.3"
+__version__ = "0.5.4a1"
 
 from .authenticator import Authenticator
 from .configuration import Config

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{38,39,310,311,312,313,314,py39,py310,py311},  # Standard install & test cpython and pypy (unofficial)
-          py{314,py311}-{min,latest},                      # Test against the earliest known good, and latest dependencies
-          py{314}-cov,                                     # Coverage must be 100%
-          py{314}-lint,                                    # Code needs to be pretty!
-          py{314}-pre,                                     # Look for upcoming potential issues.
-          py{314}-typing                                   # Ensure code is typed
+envlist = py{310,311,312,313,314,py310,py311},  # Standard install & test cpython and pypy (unofficial)
+          py{314,py311}-{min,latest},           # Test against the earliest known good, and latest dependencies
+          py{314}-cov,                          # Coverage must be 100%
+          py{314}-lint,                         # Code needs to be pretty!
+          py{314}-pre,                          # Look for upcoming potential issues.
+          py{314}-typing                        # Ensure code is typed
 
 
 [testenv]
@@ -17,18 +17,18 @@ deps = pytest-timeout
 install_command = pip install {opts} {packages}
 commands = pytest -p no:smtpd {posargs}
 
-[testenv:py{38,39,310,311,312,313,314,py39,py310,py311}-pre]
+[testenv:py{310,311,312,313,314,py39,py310,py311}-pre]
 pip_pre = true
 
-[testenv:py{38,39,310,311,312,313,314,py39,py310,py311}-cov]
+[testenv:py{310,311,312,313,314,py39,py310,py311}-cov]
 commands = pytest -p no:smtpd --cov --no-cov-on-fail --cov-fail-under=100 {posargs}
 
-[testenv:py{38,39,310,311,312,313,314,py39,py310,py311}-lint]
+[testenv:py{310,311,312,313,314,py39,py310,py311}-lint]
 deps = flake8
        isort
 commands = isort --check .
            flake8 .
 
-[testenv:py{38,39,310,311,312,313,314,py39,py310,py311}-typing]
+[testenv:py{310,311,312,313,314,py39,py310,py311}-typing]
 deps = mypy
 commands = mypy


### PR DESCRIPTION
Drops support for out-of-support versions of Python 3.8, 3.9, and PyPy 3.9.
Adds Python 3.14 as being the maximum version in Github Actions for testing.

Closes #455 