### PR TITLE
Add GitHub Copilot instructions

### DIFF
--- a/.github/copilot-custom-instructions.md
+++ b/.github/copilot-custom-instructions.md
@@ -1,0 +1,20 @@
+# GitHub Copilot Custom Instructions
+
+- Treat this repository as a small Python library for testing email delivery with a local asyncio-based SMTP server; avoid production-oriented features unless explicitly requested.
+- Keep changes minimal and preserve the public testing API, especially `smtpd`, `SMTPDFix`, `AuthController`, and `Config`.
+- Maintain compatibility with the Python versions declared in `setup.cfg`, and keep type annotations on new or changed Python code.
+- Prefer existing dependencies and standard library modules; only add new dependencies when they are clearly necessary for the task.
+- When behavior changes, update or add pytest coverage in `tests/` alongside the implementation.
+- Preserve the current TLS/authentication approach, including the `trustme`-based certificate generation used by the test fixture.
+- Validate repository changes with the established commands: `pytest -p no:smtpd`, `isort --check .`, `flake8 .`, and `mypy`.
+- Prior to pushing to the remote repository changes should be verified by running `tox` to run the complete test suite.
+- While maintaining compatibility with the minimum required version of python take steps to minimize tech debt and to use new features as they become available. Do not write version specific code.
+
+## Infrastructure
+
+- Prefer `pyenv` to install and maintain python versions for development and testing. If it is not installed suggest that the user install it.
+- Always use a virtualenv for development. Avoid using the system install of python unless absolutely necessary.
+
+## Evolution
+
+- As development moves forward suggest changes that will improve performance that would be included in these instructions as part of the updates.


### PR DESCRIPTION
This pull request adds a new `.github/copilot-custom-instructions.md` file to define repository-specific guidelines for using GitHub Copilot. The instructions clarify the project's scope, coding standards, and testing requirements to ensure consistency and maintainability.

Repository guidelines and standards:

* Added `.github/copilot-custom-instructions.md` to specify that the repository is a small Python library for testing email delivery with a local asyncio-based SMTP server, and to discourage production-oriented features unless explicitly requested.
* Outlined requirements to keep changes minimal, preserve the public testing API (notably `smtpd`, `SMTPDFix`, `AuthController`, and `Config`), maintain compatibility with declared Python versions, and retain type annotations.
* Specified testing and validation procedures, including updating or adding pytest coverage for behavior changes, and running commands like `pytest`, `isort`, `flake8`, `mypy`, and `tox` before pushing changes.
* Provided infrastructure recommendations such as preferring `pyenv` for Python version management and always using a virtualenv for development.
* Included guidance to minimize technical debt, avoid version-specific code, and suggest performance improvements as the project evolves.