### PR TITLE
Add regression coverage for socket and loop cleanup paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ Release Date: TBD
 - Dropped support for Python 3.8, 3.9, PyPy 3.9, and PyPy 3.10
 - Updated testing on macOS for GitHub Actions
 - Removed dependency on `aiosmtpd` and created a custom implementation.
+- Added regression coverage for starting SMTPDFix with a pre-bound socket and for cleaning up the event loop when shutdown hooks raise. [Issue #475](https://github.com/bebleo/smtpdfix/issues/475) [PR #479](https://github.com/bebleo/smtpdfix/pull/479) by [Wu Tongyu (@innovationty)](https://github.com/innovationty)
 
 ## Version 0.5.3
 
@@ -15,7 +16,7 @@ Release Date: 2025-11-20
 - Obsolete refences to `Config.SSL_Cert_Path` removed from the public API. [Issue #392](https://github.com/bebleo/smtpdfix/392) reported by [Holly Evans (@holly-evans)](https://github.com/holly-evans)
 - Support for Python 3.13 and 3.14 have been added.
 - Testing in tox and Github CI against PyPy 3.11 has been added; testing against PyPy 3.10 in Github CI has been dropped.
-- Fixes to improve performance when using SSL [Issue #388](https://github.com/bebleo/smtpdfix/388) [Éloi Rivard](https://github.com/azmeuk)
+- Fixes to improve performance when using SSL [Issue #388](https://github.com/bebleo/smtpdfix/388) [脡loi Rivard](https://github.com/azmeuk)
 - Updates Code of Conduct to be adapted from version 3.0 of the Contributor Convenant and revises the contact email for reporting.
 
 ## Version 0.5.2
@@ -54,7 +55,7 @@ Previously `smtpdfix` would load a `.env` file automatically using `python-doten
 Previous versions used port 8025 by default, as of version 0.5.0 a random port is used instead.
 
 - As of version 0.5.0 Smtpdfix no longer uses `python-dotenv` to load a `.env` file by default. [Issue #274](https://github.com/bebleo/smtpdfix/274) reported by [Emmanuel Belair (@e-belair)](https://github.com/e-belair)
-- A random unused port is used instead of the default 8025 port. [Issue #280](https://github.com/bebleo/smtpdfix/issues/280) [Éloi Rivard](https://github.com/azmeuk)
+- A random unused port is used instead of the default 8025 port. [Issue #280](https://github.com/bebleo/smtpdfix/issues/280) [脡loi Rivard](https://github.com/azmeuk)
 - Replaced the deprecated key `license_file` with `license_files` as per warning during build.
 
 ## Version 0.4.2

--- a/tests/test_coverage_paths.py
+++ b/tests/test_coverage_paths.py
@@ -245,6 +245,19 @@ def test_controller_init_sock_getsockname_oserror() -> None:
     assert controller.hostname
 
 
+def test_close_loop_ignores_shutdown_errors() -> None:
+    loop = Mock()
+    loop.is_closed.return_value = False
+    loop.is_running.return_value = False
+    loop.run_until_complete.side_effect = RuntimeError("boom")
+    controller = AuthController(loop=loop)
+
+    controller._close_loop()
+
+    assert loop.run_until_complete.call_count == 2
+    loop.close.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_controller_start_async_and_stop_async_branches() -> None:
     controller = AuthController()

--- a/tests/test_smtpdfix.py
+++ b/tests/test_smtpdfix.py
@@ -1,3 +1,4 @@
+import socket
 from email.message import EmailMessage
 from pathlib import Path
 from smtplib import SMTP
@@ -12,6 +13,18 @@ def test_smtpdfix(msg: EmailMessage) -> None:
     with SMTPDFix() as server, SMTP(server.hostname, server.port) as client:
         client.send_message(msg)
         assert len(server.messages) == 1
+
+
+def test_smtpdfix_with_prebound_socket(msg: EmailMessage) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(5)
+
+        with SMTPDFix(sock=sock) as server:
+            with SMTP(server.hostname, server.port) as client:
+                client.send_message(msg)
+
+            assert len(server.messages) == 1
 
 
 def test_generate_certs(tmp_path_factory: TempPathFactory) -> None:


### PR DESCRIPTION
## Summary

- exercise `SMTPDFix` with a pre-bound socket end to end
- verify loop cleanup continues if either shutdown hook raises
- restore 100% branch coverage on `new-smtpdfix`

The socket test covers the path described in #475. The implementation already avoids forwarding host/port together with `sock`; this keeps that behavior from regressing.

## Testing

- `tox -e py311-cov` — 110 passed, 100% coverage
- `tox -e py311-min,py311-latest`
- `tox -e py311-lint,py311-typing`
